### PR TITLE
More Permissions Fixes

### DIFF
--- a/netbox_floorplan/views.py
+++ b/netbox_floorplan/views.py
@@ -58,7 +58,7 @@ class FloorplanListView(generic.ObjectListView):
 
 
 class FloorplanAddView(PermissionRequiredMixin, View):
-    permission_required = "netbox_floorplan.add_floorplanobject"
+    permission_required = "netbox_floorplan.add_floorplan"
 
     def get(self, request):
         if request.GET.get("site"):
@@ -79,7 +79,7 @@ class FloorplanDeleteView(generic.ObjectDeleteView):
 
 
 class FloorplanMapEditView(LoginRequiredMixin, View):
-    permission_required = "netbox_floorplan.edit_floorplanobject"
+    permission_required = "netbox_floorplan.edit_floorplan"
 
     def get(self, request, pk):
         fp = models.Floorplan.objects.get(pk=pk)


### PR DESCRIPTION
Upon testing the merged changes from my previous PR, I discovered that I could view the floorplan tab now as a non-super-user, but couldn't create new floorplans. I looked back through the code and found more changes that would need to be made that are using the same logic as what @moonrail had discovered previously with the naming of these permissions.